### PR TITLE
chore(website): 404 early termination

### DIFF
--- a/packages/crypto-frontmatter/cli.ts
+++ b/packages/crypto-frontmatter/cli.ts
@@ -26,7 +26,7 @@ export class MirrorCommand extends Command {
     for (const namespace of await getInstalledNamespaces()) {
       let count = 0;
 
-      for (const frontmatter of await getIndex(namespace.caip2, namespace.namespace)) {
+      for (const frontmatter of (await getIndex(namespace.caip2, namespace.namespace))!) {
         if (this.includes('frontmatter.json')) {
           await this.mirrorFile(namespace, frontmatter.fileId + '.json');
           count++;

--- a/packages/crypto-frontmatter/index.ts
+++ b/packages/crypto-frontmatter/index.ts
@@ -127,12 +127,21 @@ export async function getInstalledNamespaces(): Promise<FrontmatterNamespace[]> 
  * @param namespace {string}
  * @return {FrontmatterIndex[]}
  */
-export async function getIndex(caip2: string, namespace: string): Promise<FrontmatterIndex[]> {
+export async function getIndex(caip2: string, namespace: string): Promise<FrontmatterIndex[] | undefined> {
   const path = getNodeModulesPath(caip2, namespace, 'index.json');
-  const contents = await readFile(path, {
-    encoding: 'utf-8',
-  });
-  return JSON.parse(contents);
+  try {
+    const contents = await readFile(path, {
+      encoding: 'utf-8',
+    });
+    return JSON.parse(contents);
+  } catch (err: any) {
+    // If file not found, return undefined
+    if (err.code === 'ENOENT') {
+      return undefined;
+    }
+
+    throw err;
+  }
 }
 
 /**

--- a/website/app/[caip2]/[slug]/NamespacePage.tsx
+++ b/website/app/[caip2]/[slug]/NamespacePage.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx';
 import { getIndex } from 'crypto-frontmatter';
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import { ReactElement } from 'react';
 
 export async function generateMetadata(caip2: string, namespace: string): Promise<Metadata> {
@@ -21,6 +22,10 @@ export async function generateMetadata(caip2: string, namespace: string): Promis
 
 export async function Page(props: { caip2: string; namespace: string }): Promise<ReactElement> {
   const index = await getIndex(props.caip2, props.namespace);
+  if (index === undefined) {
+    return notFound();
+  }
+
   return (
     <main>
       <div className="mx-auto w-full overflow-x-auto pb-48">

--- a/website/app/[caip2]/[slug]/page.tsx
+++ b/website/app/[caip2]/[slug]/page.tsx
@@ -37,6 +37,12 @@ export default async function Page(props: {
     slug: string;
   };
 }): Promise<ReactElement> {
+  if (props.params.caip2.startsWith('_')) {
+    // This route conflicts with public/_crypto-frontmatter static assets.
+    // This is an early termination to avoid unnecessary processing.
+    return notFound();
+  }
+
   const path = `${decodeURIComponent(props.params.caip2)}/${decodeURIComponent(props.params.slug)}`;
   const [caip2, namespace, reference] = decodeCaip19(path);
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The `[caip2]/[slug]` conflicts with `public/_crypto-frontmatter` static assets.
This is an early termination to avoid unnecessary processing.